### PR TITLE
fix: fix coder provider version to 1.0.0 to not break the template

### DIFF
--- a/2024/2024_06_genai_tooling/files/main.tf
+++ b/2024/2024_06_genai_tooling/files/main.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     coder = {
       source = "coder/coder"
+      version = "~> 1.0.0"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"


### PR DESCRIPTION
Reported by a user in Discord: https://discord.com/channels/747933592273027093/1316845123677589587/1316845123677589587